### PR TITLE
Fix compile with libadalang

### DIFF
--- a/src/stub-actions.adb
+++ b/src/stub-actions.adb
@@ -130,7 +130,7 @@ package body Stub.Actions is
      Langkit_Support.Text.To_Unbounded_Text ("elaborate_body");
 
    function Has_Elaborate_Body (N : Ada_Node) return Boolean is
-     (not P_Get_Attribute (N.As_Basic_Decl, Elaborate_Body).Is_Null);
+     (P_Has_Aspect (N.As_Basic_Decl, Elaborate_Body));
 
    ----------
    -- Init --


### PR DESCRIPTION
https://github.com/AdaCore/libadalang/commit/d0e972bb8678fdf3dcb5c866e8852b81cbff5461 broke the compile. I've replaced the call to `P_Get_Attribute` with `P_Has_Aspect`, which I'm pretty sure has the same effect