### PR TITLE
Do not exclude private subprograms from skeleton

### DIFF
--- a/src/test-skeleton.adb
+++ b/src/test-skeleton.adb
@@ -1290,10 +1290,6 @@ package body Test.Skeleton is
             return Over;
          end if;
 
-         if Node.Kind = Ada_Private_Part then
-            return Over;
-         end if;
-
          if Node.Kind = Ada_Generic_Formal_Part then
             return Over;
          end if;


### PR DESCRIPTION
Closes #16. This restores the behavior of the ASIS-based gnattest
variant. Also, this is very helpful for testing private functionality of
a package, without making the actual subprograms public.