### PR TITLE
Include binaries in "make all" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TESTSUITE_PROJECTS = \
    testsuite/ada_drivers/suppress_separate/suppress_separate.gpr
 
 ALL_PROJECTS = \
-   $(LIB_PROJECTS) $(TESTSUITE_PROJECTS)
+   $(LIB_PROJECTS) $(TESTSUITE_PROJECTS) $(BIN_PROJECTS)
 
 .PHONY: lib
 lib:


### PR DESCRIPTION
The README says that running make will build binaries in the bin/
directory, but it only built library and test components for me.  It
looks like ALL_PROJECTS was missing BIN_PROJECTS.